### PR TITLE
feat(hypr): add Hermes QuickShell desktop entry

### DIFF
--- a/hypr/default.nix
+++ b/hypr/default.nix
@@ -6,4 +6,14 @@
   home.file.".config/hypr/hyprpaper.conf".source = ./hyprpaper.conf;
   home.file.".config/hypr/screenshot.sh" = { source = ./screenshot.sh; executable = true; };
   home.file.".config/hypr/switch-workspace.sh" = { source = ./switch-workspace.sh; executable = true; };
+
+  # Hermes QuickShell: chromeless Chromium window loading the Hermes WebUI
+  # (Open WebUI on smarty, LAN). Launch via wofi/launcher, float via windowrule.
+  xdg.desktopEntries.hermes = {
+    name = "Hermes";
+    comment = "Hermes WebUI (Open WebUI)";
+    exec = "chromium --app=http://smarty:3000 --window-size=780,900";
+    terminal = false;
+    categories = [ "Utility" ];
+  };
 }


### PR DESCRIPTION
Chromeless Chromium window loading the Hermes WebUI (Open WebUI on smarty, LAN). Launchable from wofi/launcher; float via windowrule.

- `xdg.desktopEntries.hermes` in the hypr module
- `chromium --app=http://smarty:3000 --window-size=780,900`
- For tailnet machines the URL can be switched to https://smarty.tail24361f.ts.net/